### PR TITLE
Fix survey caching

### DIFF
--- a/frontend/team-health-check/src/actions/surveysActions.ts
+++ b/frontend/team-health-check/src/actions/surveysActions.ts
@@ -46,7 +46,7 @@ const surveysActions = {
     actionCreator(CREATE_SURVEY_END, payload),
   createSurveyError: (payload: string) =>
     actionCreator(CREATE_SURVEY_ERROR, payload),
-  getSurveyStart: () => actionCreator(GET_SURVEY_START),
+  getSurveyStart: (payload: string) => actionCreator(GET_SURVEY_START, payload),
   getSurveyEnd: (payload: GetSurveyResponse) =>
     actionCreator(GET_SURVEY_END, payload),
   getSurveyError: (payload: string) => actionCreator(GET_SURVEY_ERROR, payload),
@@ -99,7 +99,7 @@ export const createSurvey =
 export const getTeamSurveyDetails =
   (surveyId: string): AppThunk =>
   async (dispatch) => {
-    dispatch(surveysActions.getSurveyStart());
+    dispatch(surveysActions.getSurveyStart(surveyId));
 
     const response = await SurveysService.getSurvey(surveyId);
 

--- a/frontend/team-health-check/src/components/SurveyMetadata/SurveyMetadata.tsx
+++ b/frontend/team-health-check/src/components/SurveyMetadata/SurveyMetadata.tsx
@@ -67,7 +67,9 @@ const SurveyMetadata = ({ survey, onSurveyLinkClick, showActions }: Props) => {
             Max responses
           </Typography>
           <Typography variant="body1" component="dd">
-            {survey.maxResponses}
+            {survey.maxResponses
+              ? survey.maxResponses
+              : String.fromCodePoint(0x221e)}
           </Typography>
         </Metadata>
 

--- a/frontend/team-health-check/src/pages/Survey/Survey.tsx
+++ b/frontend/team-health-check/src/pages/Survey/Survey.tsx
@@ -41,6 +41,7 @@ const Survey = () => {
     loading: surveyLoading,
     data: survey,
     error: surveyError,
+    id: lastSurveyId,
   } = useAppSelector(selectSurveysSurveyDetails);
   const {
     loading: responsesLoading,
@@ -50,10 +51,10 @@ const Survey = () => {
   const isSurveyActive = survey ? survey.active : false;
 
   useEffect(() => {
-    if (!surveyLoading && !survey && !surveyError && surveyId) {
+    if (surveyId && lastSurveyId !== surveyId) {
       dispatch(getTeamSurveyDetails(surveyId));
     }
-  }, [surveyLoading, survey, surveyError, surveyId]);
+  }, [surveyId, lastSurveyId, dispatch]);
 
   useEffect(() => {
     if (

--- a/frontend/team-health-check/src/pages/SurveyDetails/ResponseCard.tsx
+++ b/frontend/team-health-check/src/pages/SurveyDetails/ResponseCard.tsx
@@ -100,7 +100,9 @@ const ResponseCard = ({ question, breakdown, totalReplies }: Props) => (
 
       {RESPONSE_VALUES.map((v, i) => {
         const percent =
-          (totalReplies > 0 ? breakdown[v] / totalReplies : 0) * 100;
+          totalReplies > 0
+            ? Math.round((breakdown[v] / totalReplies) * 1000) / 10
+            : 0;
         return (
           <React.Fragment key={v}>
             <Background row={i + 2}>

--- a/frontend/team-health-check/src/pages/SurveyDetails/SurveyDetails.tsx
+++ b/frontend/team-health-check/src/pages/SurveyDetails/SurveyDetails.tsx
@@ -50,9 +50,9 @@ const SurveyDetails = () => {
   const modalId = useAppSelector(selectModalId);
   const { data: teams } = useAppSelector(selectGetTeams);
   const {
-    loading: surveyLoading,
-    error: surveyError,
     data: survey,
+    id: lastSurveyId,
+    loading: surveyLoading,
   } = useAppSelector(selectSurveysSurveyDetails);
   const {
     loading: responsesLoading,
@@ -61,10 +61,10 @@ const SurveyDetails = () => {
   } = useAppSelector(selectSurveyResponses);
 
   useEffect(() => {
-    if (!survey && !surveyError && !surveyLoading && surveyId) {
+    if (surveyId && lastSurveyId !== surveyId) {
       dispatch(getTeamSurveyDetails(surveyId));
     }
-  }, [survey, surveyError, surveyLoading, surveyId, dispatch]);
+  }, [lastSurveyId, surveyId, dispatch]);
 
   useEffect(() => {
     if (!responsesLoading && !responsesError && !responses && surveyId) {
@@ -78,7 +78,7 @@ const SurveyDetails = () => {
     return <div>Could not find team {teamName}</div>;
   }
 
-  if (!responses || !survey) {
+  if (!responses || !survey || surveyLoading) {
     return <div>Loading...</div>;
   }
 

--- a/frontend/team-health-check/src/reducers/surveysReducer.ts
+++ b/frontend/team-health-check/src/reducers/surveysReducer.ts
@@ -1,4 +1,9 @@
-import updateDataState, { DataState } from '../util/updateDataState';
+import updateDataState, {
+  DataState,
+  DataStateWithId,
+  getDefaultDataState,
+  getDefaultDataStateWithId,
+} from '../util/updateDataState';
 import {
   CreateSurveyResponse,
   GetSurveyResponse,
@@ -16,43 +21,19 @@ interface SurveysState {
   create: DataState<CreateSurveyResponse>;
   selectedTeamId: string | null;
   createSurveyForm: CreateSurveyForm;
-  surveyDetails: DataState<GetSurveyResponse>;
+  surveyDetails: DataStateWithId<GetSurveyResponse>;
   surveyResponses: DataState<GetSurveyResponsesResponse>;
 }
 
 const defaultSurveysState: SurveysState = {
-  get: {
-    data: null,
-    loading: false,
-    error: null,
-    lastUpdate: null,
-    lastSuccess: null,
-  },
+  get: getDefaultDataState(),
+  create: getDefaultDataState(),
+  surveyDetails: getDefaultDataStateWithId(),
+  surveyResponses: getDefaultDataState(),
   selectedTeamId: null,
   createSurveyForm: {
     maxResponses: '',
     teamId: null,
-  },
-  create: {
-    data: null,
-    loading: false,
-    error: null,
-    lastUpdate: null,
-    lastSuccess: null,
-  },
-  surveyDetails: {
-    data: null,
-    loading: false,
-    error: null,
-    lastUpdate: null,
-    lastSuccess: null,
-  },
-  surveyResponses: {
-    data: null,
-    loading: false,
-    error: null,
-    lastUpdate: null,
-    lastSuccess: null,
   },
 };
 
@@ -131,7 +112,10 @@ const surveysReducer = (
     case 'GET_SURVEY_START':
       return {
         ...state,
-        surveyDetails: updateDataState.loading(state.surveyDetails),
+        surveyDetails: updateDataState.loading(
+          state.surveyDetails,
+          action.payload,
+        ),
       };
     case 'GET_SURVEY_END': {
       return {

--- a/frontend/team-health-check/src/util/updateDataState.ts
+++ b/frontend/team-health-check/src/util/updateDataState.ts
@@ -6,13 +6,67 @@ export interface DataState<D> {
   lastUpdate: number | null;
 }
 
-const updateDataState = {
-  loading: <D>(current: DataState<D>): DataState<D> => ({
-    ...current,
-    loading: true,
-    lastUpdate: Date.now(),
-  }),
-  success: <D>(current: DataState<D>, data: D): DataState<D> => ({
+export interface DataStateWithId<D> extends DataState<D> {
+  id: string | null;
+}
+
+export const getDefaultDataState = <D>(): DataState<D> => ({
+  loading: false,
+  data: null,
+  error: null,
+  lastSuccess: null,
+  lastUpdate: null,
+});
+
+export const getDefaultDataStateWithId = <D>(): DataStateWithId<D> => ({
+  ...getDefaultDataState<D>(),
+  id: null,
+});
+
+type LoadingFunction = {
+  <D>(current: DataState<D>): DataState<D>;
+  <D>(
+    current: DataStateWithId<D>,
+    id: DataStateWithId<D>['id'],
+  ): DataStateWithId<D>;
+};
+
+type SuccessFunction = {
+  <D, T extends DataState<D>>(current: T, data: D): T;
+};
+
+type ErrorFunction = {
+  <D, T extends DataState<D>>(
+    current: T,
+    error: DataState<D>['error'],
+    clearData?: boolean,
+  ): T;
+};
+
+interface UpdateFunctions {
+  loading: LoadingFunction;
+  success: SuccessFunction;
+  error: ErrorFunction;
+}
+
+const updateDataState: UpdateFunctions = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  loading: (current, id?): any => {
+    if (id !== undefined) {
+      return {
+        ...current,
+        loading: true,
+        id,
+        lastUpdate: Date.now(),
+      };
+    }
+    return {
+      ...current,
+      loading: true,
+      lastUpdate: Date.now(),
+    };
+  },
+  success: (current, data) => ({
     ...current,
     loading: false,
     data,
@@ -20,11 +74,7 @@ const updateDataState = {
     lastSuccess: Date.now(),
     lastUpdate: Date.now(),
   }),
-  error: <D>(
-    current: DataState<D>,
-    error: DataState<D>['error'],
-    clearData = false,
-  ): DataState<D> => ({
+  error: (current, error, clearData = false) => ({
     ...current,
     loading: false,
     data: clearData ? null : current.data,


### PR DESCRIPTION
Updated state for survey to include ID of the last survey that fetch
attempt. This value can be used to determine if the current page has
already attempted to fetch the survey it needs. Previously, if a survey
was already in the state there was no way of knowing if that was the
survey that the page needed.