### PR TITLE
Re-use userId for login if available

### DIFF
--- a/backend/team-health-check/src/index.ts
+++ b/backend/team-health-check/src/index.ts
@@ -10,6 +10,7 @@ import surveysRouter from './routers/surveys.router';
 import withJwtAuth from './middleware/auth.middleware';
 import teamsRouter from './routers/teams.router';
 import responsesRouter from './routers/responses.router';
+import withOptionalJwtAuth from './middleware/optionalAuth.middleware';
 
 const PORT = parseInt(APP_ENVIRONMENT.SERVER_PORT, 10);
 
@@ -19,7 +20,7 @@ app.use(helmet());
 app.use(cors());
 app.use(express.json());
 app.use(cookieParser());
-app.use('/login', loginRouter);
+app.use('/login', withOptionalJwtAuth, loginRouter);
 app.use('/teams', withJwtAuth, teamsRouter);
 app.use('/surveys', withJwtAuth, surveysRouter);
 app.use('/responses', withJwtAuth, responsesRouter);

--- a/backend/team-health-check/src/middleware/optionalAuth.middleware.ts
+++ b/backend/team-health-check/src/middleware/optionalAuth.middleware.ts
@@ -1,0 +1,26 @@
+import { RequestHandler } from 'express';
+import jwt from 'jsonwebtoken';
+import { JwtPayload } from '../util/jwt';
+import APP_ENVIRONMENT from '../util/environment';
+
+interface AppCookies {
+  token?: string;
+}
+
+export const withOptionalJwtAuth: RequestHandler = (req, _res, next) => {
+  const { token } = req.cookies as AppCookies;
+
+  if (!token) {
+    return next();
+  }
+
+  return jwt.verify(token, APP_ENVIRONMENT.JWT_SECRET, (e, payload) => {
+    if (!e && payload) {
+      req.jwtPayload = payload as JwtPayload;
+    }
+
+    return next();
+  });
+};
+
+export default withOptionalJwtAuth;

--- a/backend/team-health-check/src/services/login.service.ts
+++ b/backend/team-health-check/src/services/login.service.ts
@@ -2,9 +2,13 @@ import { Request, Response } from 'express';
 import { v4 as uuidV4 } from 'uuid';
 import generateJwt, { LoginResponse } from '../util/jwt';
 import sendJson from '../util/sendJson';
+import APP_ENVIRONMENT from '../util/environment';
 
-const login = async (_: Request, res: Response) => {
-  const userId = uuidV4();
+const login = async (req: Request, res: Response) => {
+  const userId =
+    !req.jwtPayload || APP_ENVIRONMENT.NEW_USER_ID_PER_JWT
+      ? uuidV4()
+      : req.jwtPayload.id;
   const { token, payload } = generateJwt(userId);
 
   res.cookie('token', token, {


### PR DESCRIPTION
Previously, the login endpoint would generate a new user ID every time a
request was made, which made for a poor user experience in the UI as the
login endpoint is hit on page load. Updated the endpoint to check if a
jwt was included in the request, and will re-use the jwt id if
available. This behavior can be overriden to return a new ID every time
(useful for testing) when running in dev mode, and by setting the
`NEW_USER_ID_PER_JWT` environment variable to a truthy value.